### PR TITLE
Pin log4j-core to 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.16.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.16.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Dependency list becomes:

```
mvn dependency:list
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< com.google.cse.creatine:creatine >------------------
[INFO] Building Google Ads Creatine 1.0.0-RELEASE
[INFO] --------------------------------[ war ]---------------------------------
Downloading from MavenCentral: http://central.maven.org/maven2/io/grpc/grpc-api/maven-metadata.xml
[WARNING] Could not transfer metadata io.grpc:grpc-api/maven-metadata.xml from/to MavenCentral (http://central.maven.org/maven2): transfer failed for http://central.maven.org/maven2/io/grpc/grpc-api/maven-metadata.xml
Downloading from MavenCentral: http://central.maven.org/maven2/io/grpc/grpc-core/maven-metadata.xml
[WARNING] Could not transfer metadata io.grpc:grpc-core/maven-metadata.xml from/to MavenCentral (http://central.maven.org/maven2): transfer failed for http://central.maven.org/maven2/io/grpc/grpc-core/maven-metadata.xml
Downloading from MavenCentral: http://central.maven.org/maven2/io/grpc/grpc-netty-shaded/maven-metadata.xml
[WARNING] Could not transfer metadata io.grpc:grpc-netty-shaded/maven-metadata.xml from/to MavenCentral (http://central.maven.org/maven2): transfer failed for http://central.maven.org/maven2/io/grpc/grpc-netty-shaded/maven-metadata.xml
[WARNING] io.grpc:grpc-api/maven-metadata.xmlfailed to transfer from http://central.maven.org/maven2 during a previous attempt. This failure was cached in the local repository and resolution will not be reattempted until the update interval of MavenCentral has elapsed or updates are forced. Original error: Could not transfer metadata io.grpc:grpc-api/maven-metadata.xml from/to MavenCentral (http://central.maven.org/maven2): transfer failed for http://central.maven.org/maven2/io/grpc/grpc-api/maven-metadata.xml
Downloading from MavenCentral: http://central.maven.org/maven2/com/google/errorprone/error_prone_annotations/maven-metadata.xml
[WARNING] Could not transfer metadata com.google.errorprone:error_prone_annotations/maven-metadata.xml from/to MavenCentral (http://central.maven.org/maven2): transfer failed for http://central.maven.org/maven2/com/google/errorprone/error_prone_annotations/maven-metadata.xml
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.1:list (default-cli) @ creatine ---
[INFO] Can't extract module name from netty-tcnative-boringssl-static-2.0.20.Final.jar: netty.tcnative.boringssl.static: Invalid module name: 'static' is not a Java identifier
[INFO] 
[INFO] The following files have been resolved:
[INFO]    org.springframework.boot:spring-boot-starter:jar:2.1.2.RELEASE:compile -- module spring.boot.starter [auto]
[INFO]    org.springframework.boot:spring-boot:jar:2.1.2.RELEASE:compile -- module spring.boot [auto]
[INFO]    org.springframework:spring-context:jar:5.1.4.RELEASE:compile -- module spring.context [auto]
[INFO]    org.springframework.boot:spring-boot-autoconfigure:jar:2.1.2.RELEASE:compile -- module spring.boot.autoconfigure [auto]
[INFO]    javax.annotation:javax.annotation-api:jar:1.3.2:compile -- module java.annotation [auto]
[INFO]    org.springframework:spring-core:jar:5.1.4.RELEASE:compile -- module spring.core [auto]
[INFO]    org.springframework:spring-jcl:jar:5.1.4.RELEASE:compile -- module spring.jcl [auto]
[INFO]    org.yaml:snakeyaml:jar:1.23:runtime -- module snakeyaml (auto)
[INFO]    javax.servlet:javax.servlet-api:jar:3.1.0:provided -- module javax.servlet.api (auto)
[INFO]    org.springframework.boot:spring-boot-starter-web:jar:2.1.2.RELEASE:compile -- module spring.boot.starter.web [auto]
[INFO]    org.springframework.boot:spring-boot-starter-json:jar:2.1.2.RELEASE:compile -- module spring.boot.starter.json [auto]
[INFO]    com.fasterxml.jackson.core:jackson-databind:jar:2.9.8:compile -- module com.fasterxml.jackson.databind [auto]
[INFO]    com.fasterxml.jackson.core:jackson-annotations:jar:2.9.0:compile -- module jackson.annotations (auto)
[INFO]    com.fasterxml.jackson.core:jackson-core:jar:2.9.8:compile -- module com.fasterxml.jackson.core [auto]
[INFO]    com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.9.8:compile -- module com.fasterxml.jackson.datatype.jdk8 [auto]
[INFO]    com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.9.8:compile -- module com.fasterxml.jackson.datatype.jsr310 [auto]
[INFO]    com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.9.8:compile -- module com.fasterxml.jackson.module.paramnames [auto]
[INFO]    org.hibernate.validator:hibernate-validator:jar:6.0.14.Final:compile -- module org.hibernate.validator [auto]
[INFO]    javax.validation:validation-api:jar:2.0.1.Final:compile -- module java.validation [auto]
[INFO]    org.jboss.logging:jboss-logging:jar:3.3.2.Final:compile -- module org.jboss.logging [auto]
[INFO]    com.fasterxml:classmate:jar:1.4.0:compile -- module com.fasterxml.classmate [auto]
[INFO]    org.springframework:spring-web:jar:5.1.4.RELEASE:compile -- module spring.web [auto]
[INFO]    org.springframework:spring-beans:jar:5.1.4.RELEASE:compile -- module spring.beans [auto]
[INFO]    org.springframework:spring-webmvc:jar:5.1.4.RELEASE:compile -- module spring.webmvc [auto]
[INFO]    org.springframework:spring-aop:jar:5.1.4.RELEASE:compile -- module spring.aop [auto]
[INFO]    org.springframework:spring-expression:jar:5.1.4.RELEASE:compile -- module spring.expression [auto]
[INFO]    com.google.api-ads:google-ads:jar:5.1.0:compile -- module google.ads (auto)
[INFO]    com.google.api:gax:jar:1.50.1:compile -- module gax (auto)
[INFO]    com.google.guava:guava:jar:28.1-android:compile -- module com.google.common [auto]
[INFO]    com.google.guava:failureaccess:jar:1.0.1:compile -- module failureaccess (auto)
[INFO]    com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile -- module listenablefuture (auto)
[INFO]    org.checkerframework:checker-compat-qual:jar:2.5.5:compile -- module org.checkerframework.checker.qual [auto]
[INFO]    com.google.errorprone:error_prone_annotations:jar:2.3.2:compile -- module error.prone.annotations (auto)
[INFO]    com.google.j2objc:j2objc-annotations:jar:1.3:compile -- module j2objc.annotations (auto)
[INFO]    org.codehaus.mojo:animal-sniffer-annotations:jar:1.18:compile -- module animal.sniffer.annotations (auto)
[INFO]    com.google.code.findbugs:jsr305:jar:3.0.2:compile -- module jsr305 (auto)
[INFO]    org.threeten:threetenbp:jar:1.3.3:compile -- module threetenbp (auto)
[INFO]    com.google.auth:google-auth-library-oauth2-http:jar:0.18.0:compile -- module com.google.auth.oauth2 [auto]
[INFO]    com.google.auto.value:auto-value-annotations:jar:1.6.6:compile -- module auto.value.annotations (auto)
[INFO]    com.google.api:api-common:jar:1.8.1:compile -- module com.google.api.apicommon [auto]
[INFO]    io.opencensus:opencensus-api:jar:0.24.0:compile -- module opencensus.api (auto)
[INFO]    io.grpc:grpc-context:jar:1.22.1:compile -- module grpc.context (auto)
[INFO]    com.google.api:gax-grpc:jar:1.50.1:compile -- module gax.grpc (auto)
[INFO]    io.grpc:grpc-stub:jar:1.25.0:compile -- module grpc.stub (auto)
[INFO]    io.grpc:grpc-api:jar:1.25.0:compile -- module grpc.api (auto)
[INFO]    io.grpc:grpc-auth:jar:1.25.0:compile -- module grpc.auth (auto)
[INFO]    io.grpc:grpc-protobuf:jar:1.25.0:compile -- module grpc.protobuf (auto)
[INFO]    io.grpc:grpc-protobuf-lite:jar:1.25.0:compile -- module grpc.protobuf.lite (auto)
[INFO]    com.google.auth:google-auth-library-credentials:jar:0.18.0:compile -- module com.google.auth [auto]
[INFO]    com.google.api.grpc:proto-google-common-protos:jar:1.15.0:compile -- module proto.google.common.protos (auto)
[INFO]    io.grpc:grpc-netty-shaded:jar:1.25.0:compile -- module grpc.netty.shaded (auto)
[INFO]    io.grpc:grpc-core:jar:1.25.0:compile -- module grpc.core (auto)
[INFO]    com.google.android:annotations:jar:4.1.1.4:compile -- module annotations (auto)
[INFO]    io.perfmark:perfmark-api:jar:0.19.0:compile -- module perfmark.api (auto)
[INFO]    io.opencensus:opencensus-contrib-grpc-metrics:jar:0.21.0:compile -- module opencensus.contrib.grpc.metrics (auto)
[INFO]    io.grpc:grpc-alts:jar:1.25.0:compile -- module grpc.alts (auto)
[INFO]    io.grpc:grpc-grpclb:jar:1.25.0:compile -- module grpc.grpclb (auto)
[INFO]    org.apache.commons:commons-lang3:jar:3.8.1:compile -- module org.apache.commons.lang3 [auto]
[INFO]    org.conscrypt:conscrypt-openjdk-uber:jar:2.2.1:compile -- module org.conscrypt [auto]
[INFO]    io.netty:netty-tcnative-boringssl-static:jar:2.0.20.Final:compile
[INFO]    org.slf4j:slf4j-api:jar:1.7.25:compile -- module slf4j.api (auto)
[INFO]    com.google.cloud:google-cloud-bigquery:jar:1.101.0:compile -- module google.cloud.bigquery (auto)
[INFO]    com.google.cloud:google-cloud-core:jar:1.91.3:compile -- module google.cloud.core (auto)
[INFO]    com.google.protobuf:protobuf-java-util:jar:3.10.0:compile -- module com.google.protobuf.util [auto]
[INFO]    com.google.code.gson:gson:jar:2.8.5:compile -- module gson (auto)
[INFO]    com.google.api.grpc:proto-google-iam-v1:jar:0.13.0:compile -- module proto.google.iam.v1 (auto)
[INFO]    com.google.http-client:google-http-client:jar:1.32.1:compile -- module com.google.api.client [auto]
[INFO]    org.apache.httpcomponents:httpclient:jar:4.5.6:compile -- module org.apache.httpcomponents.httpclient [auto]
[INFO]    commons-codec:commons-codec:jar:1.11:compile -- module org.apache.commons.codec [auto]
[INFO]    org.apache.httpcomponents:httpcore:jar:4.4.10:compile -- module org.apache.httpcomponents.httpcore [auto]
[INFO]    com.google.http-client:google-http-client-jackson2:jar:1.32.1:compile -- module com.google.api.client.json.jackson2 [auto]
[INFO]    com.google.cloud:google-cloud-core-http:jar:1.91.3:compile -- module google.cloud.core.http (auto)
[INFO]    com.google.api-client:google-api-client:jar:1.30.4:compile -- module google.api.client [auto]
[INFO]    com.google.http-client:google-http-client-appengine:jar:1.32.1:compile -- module com.google.api.client.extensions.appengine [auto]
[INFO]    com.google.api:gax-httpjson:jar:0.66.1:compile -- module gax.httpjson (auto)
[INFO]    io.opencensus:opencensus-contrib-http-util:jar:0.24.0:compile -- module opencensus.contrib.http.util (auto)
[INFO]    com.google.apis:google-api-services-bigquery:jar:v2-rev20190917-1.30.3:compile -- module com.google.api.services.bigquery [auto]
[INFO]    com.google.cloud:google-cloud-datastore:jar:1.101.0:compile -- module google.cloud.datastore (auto)
[INFO]    com.google.api.grpc:proto-google-cloud-datastore-v1:jar:0.84.0:compile -- module proto.google.cloud.datastore.v1 (auto)
[INFO]    com.google.cloud.datastore:datastore-v1-proto-client:jar:1.6.3:compile -- module datastore.v1.proto.client (auto)
[INFO]    com.google.http-client:google-http-client-protobuf:jar:1.33.0:compile -- module com.google.api.client.http.protobuf [auto]
[INFO]    com.google.oauth-client:google-oauth-client:jar:1.30.4:compile -- module com.google.api.client.auth [auto]
[INFO]    com.google.cloud:google-cloud-storage:jar:1.101.0:compile -- module google.cloud.storage (auto)
[INFO]    com.google.apis:google-api-services-storage:jar:v1-rev20190910-1.30.3:compile -- module com.google.api.services.storage [auto]
[INFO]    com.google.appengine:appengine-api-1.0-sdk:jar:1.9.77:compile -- module appengine.api (auto)
[INFO]    com.google.protobuf:protobuf-java:jar:3.10.0:compile -- module com.google.protobuf [auto]
[INFO]    org.powermock:powermock-module-junit4:jar:2.0.2:test -- module powermock.module.junit4 (auto)
[INFO]    org.powermock:powermock-module-junit4-common:jar:2.0.2:test -- module powermock.module.junit4.common (auto)
[INFO]    org.powermock:powermock-reflect:jar:2.0.2:test -- module powermock.reflect (auto)
[INFO]    net.bytebuddy:byte-buddy:jar:1.9.7:test -- module net.bytebuddy
[INFO]    net.bytebuddy:byte-buddy-agent:jar:1.9.7:test -- module net.bytebuddy.agent
[INFO]    org.powermock:powermock-core:jar:2.0.2:test -- module powermock.core (auto)
[INFO]    org.javassist:javassist:jar:3.24.0-GA:test -- module javassist (auto)
[INFO]    junit:junit:jar:4.12:test -- module junit (auto)
[INFO]    org.hamcrest:hamcrest-core:jar:1.3:test -- module hamcrest.core (auto)
[INFO]    org.powermock:powermock-api-mockito2:jar:2.0.2:test -- module powermock.api.mockito2 (auto)
[INFO]    org.powermock:powermock-api-support:jar:2.0.2:test -- module powermock.api.support (auto)
[INFO]    org.mockito:mockito-core:jar:2.23.4:test -- module org.mockito [auto]
[INFO]    org.objenesis:objenesis:jar:2.6:test -- module objenesis (auto)
[INFO]    org.apache.logging.log4j:log4j-slf4j-impl:jar:2.16.0:compile -- module org.apache.logging.log4j.slf4j [auto]
[INFO]    org.apache.logging.log4j:log4j-api:jar:2.11.1:compile -- module org.apache.logging.log4j
[INFO]    org.apache.logging.log4j:log4j-core:jar:2.16.0:compile -- module org.apache.logging.log4j.core [auto]
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.501 s
[INFO] Finished at: 2021-12-17T09:17:39-08:00
[INFO] ------------------------------------------------------------------------
```